### PR TITLE
Fixed 'SAXParseException' when reading input files in Turtle format.

### DIFF
--- a/prototype/generateRML.ipynb
+++ b/prototype/generateRML.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 3,
    "id": "69834139",
    "metadata": {},
    "outputs": [
@@ -14,7 +14,7 @@
        " 'CSV File': 'http://semweb.mmlab.be/ns/ql#CSV'}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -33,13 +33,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "id": "ed2bc8e3",
    "metadata": {},
    "outputs": [],
    "source": [
     "#Read input into inputGraph\n",
-    "inputGraph = Graph().parse(\"input_schema.ttl\")\n",
+    "inputGraph = Graph().parse(\"input_schema.ttl\", format=\"ttl\")\n",
     "#import pprint\n",
     "#for stmt in inputGraph:\n",
     "# pprint.pprint(stmt)"
@@ -47,13 +47,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "id": "aede640b",
    "metadata": {},
    "outputs": [],
    "source": [
     "#Read mapping into mappingGraph\n",
-    "mappingGraph = Graph().parse(\"mapping.ttl\")\n",
+    "mappingGraph = Graph().parse(\"mapping.ttl\", format=\"ttl\")\n",
     "#import pprint\n",
     "#for stmt in mappingGraph:\n",
     "#    pprint.pprint(stmt)"
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "id": "d526de55",
    "metadata": {},
    "outputs": [],
@@ -92,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "id": "a41e5096",
    "metadata": {},
    "outputs": [
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "id": "77c61dfb",
    "metadata": {},
    "outputs": [],
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "id": "334eab35",
    "metadata": {},
    "outputs": [],
@@ -261,7 +261,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.9"
+   "version": "3.10.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
When running the Notebook on [Fedora 35](https://getfedora.org/en/workstation/) with Python 3.10.2 and RDFLib 5.0.0 I get a `SAXParseException` when executing the following two  lines:

`inputGraph = Graph().parse("input_schema.ttl")`
..
`mappingGraph = Graph().parse("mapping.ttl")`

Apparently RDFLib fails to detect the Turtle file format properly and tries to parse it as XML. Adding the format as an argument to the function fixes the errors and the notebook runs correctly:

`inputGraph = Graph().parse("input_schema.ttl", format="ttl")` 
..
`mappingGraph = Graph().parse("mapping.ttl", format="ttl")`